### PR TITLE
Fix bash functions in setup script

### DIFF
--- a/.devcontainer/setup-dev-container.sh
+++ b/.devcontainer/setup-dev-container.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Unset any inherited function definitions for nvs and nvsudo
+unset -f nvs nvsudo
+unset BASH_FUNC_nvs%% BASH_FUNC_nvsudo%%
+
 # Function to show step progress
 show_progress() {
     echo "⌛ $1..."


### PR DESCRIPTION
Unset problematic functions `nvs` and `nvsudo` at the start of the script.

* Add `unset -f nvs nvsudo` after the shebang line.
* Add `unset BASH_FUNC_nvs%% BASH_FUNC_nvsudo%%` after the shebang line.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/joshyorko/joshyorko_devcontainer/pull/5?shareId=a8fc15d5-a640-4d39-bdb8-fdddb3123ac5).